### PR TITLE
fix: dedup timeline entries by ID token, merge same-day sections

### DIFF
--- a/scripts/generate-timeline.sh
+++ b/scripts/generate-timeline.sh
@@ -5,87 +5,120 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 
-REPOS="${INPUT_REPOS:?REPOS input required}"
-DAYS="${INPUT_DAYS:-7}"
-SINCE=$(days_ago "$DAYS")
-RUN_DATE=$(date -u +%Y-%m-%d)
+# Dedup by ID token ([PR #N], [ISSUE #N], or [<short-sha>]) so that state/date
+# drift on an existing item does not cause a duplicate append.
+# Args: $1 = newline-separated items, $2 = existing output file
+# Prints: filtered items (only those whose ID is absent from the file)
+dedup_items() {
+    local items="$1" file="$2"
+    [[ ! -f "$file" ]] && { printf '%s' "$items"; return; }
+    local filtered="" line id
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        id=$(printf '%s' "$line" | grep -oE '\[(PR|ISSUE) #[0-9]+\]|\[[a-f0-9]{7,}\]' | head -1)
+        if [[ -n "$id" ]] && grep -qF "$id" "$file"; then
+            continue
+        fi
+        filtered+="$line"$'\n'
+    done <<< "$items"
+    printf '%s' "$filtered"
+}
 
-IFS=',' read -ra REPO_LIST <<< "$REPOS"
-for repo in "${REPO_LIST[@]}"; do
-    repo=$(echo "$repo" | xargs) # trim whitespace
-    owner="${repo%%/*}"
-    name="${repo##*/}"
-    mkdir -p "timelines/${owner}"
-    OUTPUT_FILE="timelines/${owner}/${name}.md"
-
-    echo "Collecting from $repo..."
-
-    # Collect new activity
-    NEW_ITEMS=""
-
-    # Issues
-    ISSUES=$("${SCRIPT_DIR}/collect-issues.sh" "$repo" "$SINCE" 2>/dev/null || true)
-    if [[ -n "$ISSUES" ]]; then
-        NEW_ITEMS+=$(echo "$ISSUES" | jq -r '"- [ISSUE #\(.number)] \(.title) (\(.date)) [\(.state)]"')
-        NEW_ITEMS+=$'\n'
+# Append items to the output file. If a '## RUN_DATE' header already exists,
+# append without a new header; otherwise create a new date section.
+# Args: $1 = output file, $2 = run date, $3 = items
+append_section() {
+    local file="$1" run_date="$2" items="$3"
+    if grep -qxF "## $run_date" "$file" 2>/dev/null; then
+        printf '%s' "$items" >> "$file"
+    else
+        {
+            echo "## $run_date"
+            echo ""
+            printf '%s' "$items"
+            echo ""
+        } >> "$file"
     fi
+}
 
-    # PRs
-    PRS=$("${SCRIPT_DIR}/collect-prs.sh" "$repo" "$SINCE" 2>/dev/null || true)
-    if [[ -n "$PRS" ]]; then
-        NEW_ITEMS+=$(echo "$PRS" | jq -r '"- [PR #\(.number)] \(.title) (\(.date)) [\(.state)]"')
-        NEW_ITEMS+=$'\n'
-    fi
+main() {
+    local REPOS="${INPUT_REPOS:?REPOS input required}"
+    local DAYS="${INPUT_DAYS:-7}"
+    local SINCE
+    SINCE=$(days_ago "$DAYS")
+    local RUN_DATE
+    RUN_DATE=$(date -u +%Y-%m-%d)
 
-    # Git log (optional)
-    if [[ "${INPUT_INCLUDE_GIT_LOG:-false}" == "true" ]]; then
-        COMMITS=$(gh api "repos/$repo/commits?since=${SINCE}T00:00:00Z&per_page=20" \
-            --jq '.[] | {date: .commit.author.date[:10], sha: .sha[:7], message: (.commit.message | split("\n")[0])}' 2>/dev/null || true)
-        if [[ -n "$COMMITS" ]]; then
-            NEW_ITEMS+=$(echo "$COMMITS" | jq -r '"- [\(.sha)] \(.message) (\(.date))"')
+    IFS=',' read -ra REPO_LIST <<< "$REPOS"
+    for repo in "${REPO_LIST[@]}"; do
+        repo=$(echo "$repo" | xargs) # trim whitespace
+        local owner="${repo%%/*}"
+        local name="${repo##*/}"
+        mkdir -p "timelines/${owner}"
+        local OUTPUT_FILE="timelines/${owner}/${name}.md"
+
+        echo "Collecting from $repo..."
+
+        # Collect new activity
+        local NEW_ITEMS=""
+
+        # Issues
+        local ISSUES
+        ISSUES=$("${SCRIPT_DIR}/collect-issues.sh" "$repo" "$SINCE" 2>/dev/null || true)
+        if [[ -n "$ISSUES" ]]; then
+            NEW_ITEMS+=$(echo "$ISSUES" | jq -r '"- [ISSUE #\(.number)] \(.title) (\(.date)) [\(.state)]"')
             NEW_ITEMS+=$'\n'
         fi
-    fi
 
-    # Skip if no new activity
-    if [[ -z "${NEW_ITEMS// /}" ]]; then
-        echo "No new activity for $repo"
-        continue
-    fi
+        # PRs
+        local PRS
+        PRS=$("${SCRIPT_DIR}/collect-prs.sh" "$repo" "$SINCE" 2>/dev/null || true)
+        if [[ -n "$PRS" ]]; then
+            NEW_ITEMS+=$(echo "$PRS" | jq -r '"- [PR #\(.number)] \(.title) (\(.date)) [\(.state)]"')
+            NEW_ITEMS+=$'\n'
+        fi
 
-    # Dedup: filter out lines already in existing file
-    if [[ -f "$OUTPUT_FILE" ]]; then
-        FILTERED=""
-        while IFS= read -r line; do
-            [[ -z "$line" ]] && continue
-            if ! grep -qF "$line" "$OUTPUT_FILE"; then
-                FILTERED+="$line"$'\n'
+        # Git log (optional)
+        if [[ "${INPUT_INCLUDE_GIT_LOG:-false}" == "true" ]]; then
+            local COMMITS
+            COMMITS=$(gh api "repos/$repo/commits?since=${SINCE}T00:00:00Z&per_page=20" \
+                --jq '.[] | {date: .commit.author.date[:10], sha: .sha[:7], message: (.commit.message | split("\n")[0])}' 2>/dev/null || true)
+            if [[ -n "$COMMITS" ]]; then
+                NEW_ITEMS+=$(echo "$COMMITS" | jq -r '"- [\(.sha)] \(.message) (\(.date))"')
+                NEW_ITEMS+=$'\n'
             fi
-        done <<< "$NEW_ITEMS"
-        NEW_ITEMS="$FILTERED"
-    fi
+        fi
 
-    # Skip if all items already exist
-    if [[ -z "${NEW_ITEMS// /}" ]]; then
-        echo "No new unique items for $repo"
-        continue
-    fi
+        # Skip if no new activity
+        if [[ -z "${NEW_ITEMS// /}" ]]; then
+            echo "No new activity for $repo"
+            continue
+        fi
 
-    # Create header if file doesn't exist
-    if [[ ! -f "$OUTPUT_FILE" ]]; then
-        {
-            echo "# $repo — Timeline"
-            echo ""
-        } > "$OUTPUT_FILE"
-    fi
+        # Dedup against existing file
+        NEW_ITEMS=$(dedup_items "$NEW_ITEMS" "$OUTPUT_FILE")
 
-    # Append new date section
-    {
-        echo "## $RUN_DATE"
-        echo ""
-        printf '%s' "$NEW_ITEMS"
-        echo ""
-    } >> "$OUTPUT_FILE"
+        # Skip if all items already exist
+        if [[ -z "${NEW_ITEMS// /}" ]]; then
+            echo "No new unique items for $repo"
+            continue
+        fi
 
-    echo "Timeline updated: $OUTPUT_FILE"
-done
+        # Create header if file doesn't exist
+        if [[ ! -f "$OUTPUT_FILE" ]]; then
+            {
+                echo "# $repo — Timeline"
+                echo ""
+            } > "$OUTPUT_FILE"
+        fi
+
+        append_section "$OUTPUT_FILE" "$RUN_DATE" "$NEW_ITEMS"
+
+        echo "Timeline updated: $OUTPUT_FILE"
+    done
+}
+
+# Run main only when invoked as a script (not when sourced for tests)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/unit/test_generate_timeline.bats
+++ b/tests/unit/test_generate_timeline.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+# Tests for dedup_items and append_section helpers in generate-timeline.sh.
+
+setup() {
+    OUTPUT_FILE="$(mktemp -t timeline.XXXXXX)"
+    # Source the script without triggering main()
+    source "$BATS_TEST_DIRNAME/../../scripts/generate-timeline.sh"
+}
+
+teardown() {
+    rm -f "$OUTPUT_FILE"
+}
+
+# --- dedup_items ---
+
+@test "dedup_items returns input unchanged when file does not exist" {
+    rm -f "$OUTPUT_FILE"
+    input=$'- [ISSUE #1] foo (2026-04-01) [open]\n- [PR #2] bar (2026-04-02) [open]\n'
+    result=$(dedup_items "$input" "$OUTPUT_FILE")
+    # command substitution strips trailing newlines; compare without them
+    [ "$result" = "${input%$'\n'}" ]
+}
+
+@test "dedup_items filters lines whose ID token already appears in file" {
+    printf -- '- [ISSUE #1] foo (2026-04-01) [open]\n' > "$OUTPUT_FILE"
+    input=$'- [ISSUE #1] foo (2026-04-10) [closed]\n- [PR #2] bar (2026-04-02) [open]\n'
+    result=$(dedup_items "$input" "$OUTPUT_FILE")
+    # ISSUE #1 dropped (state changed but ID exists); PR #2 kept
+    [[ "$result" != *"ISSUE #1"* ]]
+    [[ "$result" == *"PR #2"* ]]
+}
+
+@test "dedup_items dedups by short SHA token" {
+    printf -- '- [a1b2c3d] msg (2026-04-01)\n' > "$OUTPUT_FILE"
+    input=$'- [a1b2c3d] msg (2026-04-01)\n- [deadbee] other (2026-04-02)\n'
+    result=$(dedup_items "$input" "$OUTPUT_FILE")
+    [[ "$result" != *"a1b2c3d"* ]]
+    [[ "$result" == *"deadbee"* ]]
+}
+
+@test "dedup_items keeps lines with no recognizable ID token" {
+    printf -- '- existing\n' > "$OUTPUT_FILE"
+    input=$'- plain line without id\n'
+    result=$(dedup_items "$input" "$OUTPUT_FILE")
+    [[ "$result" == *"plain line without id"* ]]
+}
+
+# --- append_section ---
+
+@test "append_section creates new date header when absent" {
+    : > "$OUTPUT_FILE"
+    items=$'- [ISSUE #1] foo (2026-04-23) [open]\n'
+    append_section "$OUTPUT_FILE" "2026-04-23" "$items"
+    [ "$(grep -c '^## 2026-04-23$' "$OUTPUT_FILE")" -eq 1 ]
+    grep -q 'ISSUE #1' "$OUTPUT_FILE"
+}
+
+@test "append_section does not duplicate date header when present" {
+    printf '## 2026-04-23\n\n- [ISSUE #1] foo (2026-04-23) [open]\n\n' > "$OUTPUT_FILE"
+    items=$'- [PR #2] bar (2026-04-23) [open]\n'
+    append_section "$OUTPUT_FILE" "2026-04-23" "$items"
+    # Still exactly one date header; both items present
+    [ "$(grep -c '^## 2026-04-23$' "$OUTPUT_FILE")" -eq 1 ]
+    grep -q 'ISSUE #1' "$OUTPUT_FILE"
+    grep -q 'PR #2' "$OUTPUT_FILE"
+}
+
+# --- Integration: dedup + append together ---
+
+@test "dedup + append: state transition does not duplicate entry" {
+    # Seed: issue #42 was open on an earlier run
+    printf '# repo — Timeline\n\n## 2026-04-20\n\n- [ISSUE #42] fix bug (2026-04-20) [open]\n\n' > "$OUTPUT_FILE"
+    # Same issue now closed
+    incoming=$'- [ISSUE #42] fix bug (2026-04-23) [closed]\n'
+    filtered=$(dedup_items "$incoming" "$OUTPUT_FILE")
+    # Nothing to append
+    [ -z "$filtered" ]
+    # File still has exactly one [ISSUE #42]
+    [ "$(grep -c 'ISSUE #42' "$OUTPUT_FILE")" -eq 1 ]
+}
+
+@test "dedup + append: two runs same day produce single date header" {
+    printf '# repo — Timeline\n\n' > "$OUTPUT_FILE"
+    # Run 1
+    items_a=$'- [ISSUE #1] a (2026-04-23) [open]\n'
+    filtered_a=$(dedup_items "$items_a" "$OUTPUT_FILE")
+    append_section "$OUTPUT_FILE" "2026-04-23" "$filtered_a"
+    # Run 2, same day, different item
+    items_b=$'- [PR #2] b (2026-04-23) [open]\n'
+    filtered_b=$(dedup_items "$items_b" "$OUTPUT_FILE")
+    append_section "$OUTPUT_FILE" "2026-04-23" "$filtered_b"
+    # Single date header, both items present
+    [ "$(grep -c '^## 2026-04-23$' "$OUTPUT_FILE")" -eq 1 ]
+    grep -q 'ISSUE #1' "$OUTPUT_FILE"
+    grep -q 'PR #2' "$OUTPUT_FILE"
+}


### PR DESCRIPTION
Root cause: `scripts/generate-timeline.sh` dedup compared full lines (`grep -qF "$line"`) including trailing `[state]`, so any open→closed transition re-appended. The date header `## RUN_DATE` was also appended unconditionally, producing duplicates on same-day reruns.

Fix:
- `dedup_items()` — keys on `[PR #N]`/`[ISSUE #N]`/`[<sha>]` token, not the full line.
- `append_section()` — reuses existing `## RUN_DATE` header if present; creates a new date section otherwise.
- Main flow wrapped in `main()`; `BASH_SOURCE` guard so the script can be sourced from tests without executing.

Tests: new `tests/unit/test_generate_timeline.bats` — 8 cases covering dedup by token type, state-transition dedup, same-day header reuse.

Closes #23