### PR TITLE
fix: refresh SVG every run + paginate issues endpoint

### DIFF
--- a/scripts/collect-activity-counts.sh
+++ b/scripts/collect-activity-counts.sh
@@ -48,7 +48,9 @@ emit_issue_events() {
   (if .closed_at != null and (.state_reason != "completed") and .closed_at[:10] >= "$SINCE" then "\(.closed_at[:10])\tissue-closed" else empty end)
 EOF
 )
-    gh api "repos/${REPO}/issues?state=all&since=${SINCE}T00:00:00Z&per_page=100" --jq "$filter" | bucket
+    # --paginate: /issues mixes issues+PRs ordered by updated_at; on PR-heavy
+    # repos issues fall past page 1 if we don't sweep all pages.
+    gh api --paginate "repos/${REPO}/issues?state=all&since=${SINCE}T00:00:00Z&per_page=100" --jq "$filter" | bucket
 }
 
 emit_commits() {

--- a/scripts/collect-issues.sh
+++ b/scripts/collect-issues.sh
@@ -6,5 +6,7 @@ set -euo pipefail
 REPO="${1:?Usage: collect-issues.sh owner/repo since-date}"
 SINCE="${2:?Missing since date}"
 
-gh api "repos/$REPO/issues?state=all&since=${SINCE}T00:00:00Z&per_page=100" \
+# --paginate: /issues mixes issues+PRs ordered by updated_at; on PR-heavy
+# repos real issues fall past page 1 if we don't sweep all pages.
+gh api --paginate "repos/$REPO/issues?state=all&since=${SINCE}T00:00:00Z&per_page=100" \
     --jq '.[] | select(.pull_request == null) | {date: .created_at[:10], repo: "'"$REPO"'", type: "issue", number: .number, title: .title, state: .state, url: .html_url}'

--- a/scripts/generate-timeline.sh
+++ b/scripts/generate-timeline.sh
@@ -106,32 +106,28 @@ main() {
             fi
         fi
 
-        # Skip if no new activity
-        if [[ -z "${NEW_ITEMS// /}" ]]; then
+        # Update the timeline MD if there's anything new (dedup-aware).
+        if [[ -n "${NEW_ITEMS// /}" ]]; then
+            NEW_ITEMS=$(dedup_items "$NEW_ITEMS" "$OUTPUT_FILE")
+            if [[ -n "${NEW_ITEMS// /}" ]]; then
+                if [[ ! -f "$OUTPUT_FILE" ]]; then
+                    {
+                        echo "# $repo — Timeline"
+                        echo ""
+                    } > "$OUTPUT_FILE"
+                fi
+                append_section "$OUTPUT_FILE" "$RUN_DATE" "$NEW_ITEMS"
+                echo "Timeline updated: $OUTPUT_FILE"
+            else
+                echo "No new unique items for $repo"
+            fi
+        else
             echo "No new activity for $repo"
-            continue
         fi
 
-        # Dedup against existing file
-        NEW_ITEMS=$(dedup_items "$NEW_ITEMS" "$OUTPUT_FILE")
-
-        # Skip if all items already exist
-        if [[ -z "${NEW_ITEMS// /}" ]]; then
-            echo "No new unique items for $repo"
-            continue
-        fi
-
-        # Create header if file doesn't exist
-        if [[ ! -f "$OUTPUT_FILE" ]]; then
-            {
-                echo "# $repo — Timeline"
-                echo ""
-            } > "$OUTPUT_FILE"
-        fi
-
-        append_section "$OUTPUT_FILE" "$RUN_DATE" "$NEW_ITEMS"
-
-        # Generate / refresh the themed activity SVG and embed once.
+        # Always refresh the activity SVG — its 30-day window is wider than
+        # the timeline lookback, so the chart goes stale if we only refresh
+        # when MD items are appended. Embed is idempotent (marker-guarded).
         local ASSETS_DIR="assets/${owner}"
         local ASSET_FILE="${ASSETS_DIR}/${name}-activity.svg"
         local TSV
@@ -145,8 +141,6 @@ main() {
             echo "WARN: failed to collect activity counts for $repo (skipping SVG)"
         fi
         rm -f "$TSV"
-
-        echo "Timeline updated: $OUTPUT_FILE"
     done
 }
 

--- a/tests/unit/test_collect_activity_counts.bats
+++ b/tests/unit/test_collect_activity_counts.bats
@@ -17,14 +17,16 @@ setup() {
 set -e
 JQ=""
 URL=""
+PAGINATE=0
 while [[ \$# -gt 0 ]]; do
     case "\$1" in
         --jq) JQ="\$2"; shift 2 ;;
+        --paginate) PAGINATE=1; shift ;;
         api) shift ;;
         *) [[ -z "\$URL" ]] && URL="\$1"; shift ;;
     esac
 done
-echo "\$URL" >> "$MOCK_LOG"
+echo "PAGINATE=\$PAGINATE \$URL" >> "$MOCK_LOG"
 case "\$URL" in
     *"/issues?"*) FX="$FIXTURE_DIR/gh-mock-issues.json" ;;
     *"/pulls?"*) FX="$FIXTURE_DIR/gh-mock-prs.json" ;;
@@ -127,6 +129,14 @@ count_for() {
     run "$SCRIPT" qte77/example 9999
     [ "$status" -eq 0 ]
     grep -q 'since=' "$MOCK_LOG"
+}
+
+@test "paginates the /issues call so issues are not lost behind PRs" {
+    run "$SCRIPT" qte77/example 9999
+    [ "$status" -eq 0 ]
+    # The /issues endpoint mixes issues and PRs ordered by updated_at.
+    # Heavy-PR repos push real issues past page 1 — must paginate.
+    grep -q '^PAGINATE=1 .*/issues?' "$MOCK_LOG"
 }
 
 @test "skips commits unless INPUT_INCLUDE_GIT_LOG=true" {


### PR DESCRIPTION
## Summary

Two bugs surfaced after PR #90 landed:

### Bug A — SVG goes stale

`scripts/generate-timeline.sh` placed the SVG generation block inside the *"no new unique items, continue"* early-return. When the 7-day timeline window had nothing new, the 30-day chart never regenerated. Confirmed by inspecting `assets/qte77/gha-arbitrary-repo-timeline-activity.svg` on `main` — last updated 21:20:07Z, before PR #90 merged at 21:26:53Z, so it still rendered with PR #84's 3-token data.

**Fix**: restructured `main()` so the MD update path is gated on having new items but the SVG generation always runs. Embed call is already idempotent (marker-guarded `<\!-- activity-svg-embed -->`).

### Bug B — Issues missing from MD and chart

GitHub's `/issues` endpoint returns issues+PRs ordered by `updated_at`. On PR-heavy repos like this one, the first 100 results are 100 PRs and real issues fall past the pagination cliff. Result: the MD has zero `[ISSUE #N]` entries even though issues #4, #83, #86, #87, #88 exist; the chart has zero issue data bars (only the 3 legend swatches).

**Fix**: added `--paginate` to the `gh api ... /issues` calls in:
- `scripts/collect-issues.sh` (drives MD entries)
- `scripts/collect-activity-counts.sh` (drives chart bars)

`/pulls` is dedicated and unaffected.

## Tests

- `tests/unit/test_collect_activity_counts.bats` — mock now records `$PAGINATE` state per call; new test asserts `--paginate` is set on the `/issues` invocation.
- All other tests unchanged. **70/70 green at HEAD.**

## Test plan

- [x] `bats -r tests/` — 70/70 green
- [ ] Post-merge: run `gh workflow run update-timeline.yml --ref main` and verify the regenerated SVG includes issue data bars and the timeline MD has `[ISSUE #N]` entries.

## Follow-up

Tracker for cumulative-history TSV pattern (issue to be filed) — would let us show longer windows without re-querying the API every run.

## Checklist
- [x] Tests pass
- [ ] CHANGELOG (deferred to housekeeping PR)

Generated with Claude <noreply@anthropic.com>