### PR TITLE
fix(ci): grant issues: read to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/update-timeline.yml
+++ b/.github/workflows/update-timeline.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: read
 
 jobs:
   update:


### PR DESCRIPTION
## Summary

Root cause for the "no issues in MD or SVG" problem. PR #95 added `--paginate` (correct, but not the actual fix). The deeper bug: `update-timeline.yml`'s `permissions:` block declared only `contents: write` and `pull-requests: write`. With an explicit subset, GitHub's `GITHUB_TOKEN` model strips access to anything not listed — including `/issues`. Result: `gh api repos/<r>/issues` returned empty, `collect-issues.sh` and `collect-activity-counts.sh` emitted no issue rows, the MD never gained `[ISSUE #N]` entries and the chart never gained issue data bars (only the 3 legend swatches).

## Fix

One-line addition to permissions:

```diff
 permissions:
   contents: write
   pull-requests: write
+  issues: read
```

Read-only is sufficient — the action only enumerates and parses; it doesn't write to issues.

## Test plan

- [x] `bats -r tests/` — 70/70 unchanged (no script changes)
- [ ] Post-merge: `gh workflow run update-timeline.yml --ref main`. Expect:
  - `assets/qte77/gha-arbitrary-repo-timeline-activity.svg` to gain issue data bars (should see e.g. `2026-04-13: issue-opened, 2026-04-23: issue-resolved x2, 2026-05-08: issue-opened x4`)
  - `timelines/qte77/gha-arbitrary-repo-timeline.md` to gain `[ISSUE #N] {title} (date) [open]` entries

## Related

- Refs #95 (added `--paginate`, also necessary for high-volume repos in the future even if not the cause here)
- Refs #84 #90 (introduced the SVG with this bug latent)

## Checklist
- [x] Tests pass (no script changes)
- [ ] CHANGELOG (deferred)

Generated with Claude <noreply@anthropic.com>