### PR TITLE
chore: add .gitignore for local dev artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Local dev environment shells / configs
+.bash_profile
+.bashrc
+.zshrc
+.zprofile
+.profile
+.gitconfig
+.bash_history
+.ripgreprc
+
+# Editor / IDE
+.idea/
+.vscode/
+
+# Local secrets — must never be committed
+.env
+.env.local
+.env.*.local
+
+# MCP local server config (per-user)
+.mcp.json
+
+# Auto-memory artifact (memory itself lives under ~/.claude/projects/)
+/MEMORY.md
+
+# Claude personal config (project /.claude/settings.json IS tracked)
+/.claude/agents/
+/.claude/commands/
+/.claude/skills/
+
+# Test/coverage scratch
+.coverage
+.pytest_cache/
+.hypothesis/
+.ruff_cache/
+.complexipy_cache/
+
+# Submodule scratch (no real submodules in this repo)
+.gitmodules
+
+# OS junk
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary

Adds a `.gitignore` covering the 15 untracked dotfiles that have been polluting `git status` since this session-arc started, plus standard test/coverage scratch dirs and OS junk.

## Priority

`.env` exclusion — eliminates accidental-commit risk on `git add .`. The other entries are noise reduction.

## What's covered

- Local shell / dev configs: `.bashrc`, `.zshrc`, `.profile`, `.gitconfig`, `.ripgreprc`, `.bash_history`, …
- Editor / IDE: `.idea/`, `.vscode/`
- Secrets: `.env`, `.env.local`, `.env.*.local`
- Per-user Claude config: `/.claude/agents/`, `/.claude/commands/`, `/.claude/skills/` (project `.claude/settings.json` remains tracked)
- Auto-memory leftover: `/MEMORY.md` (real memory lives at `~/.claude/projects/<sanitized-cwd>/memory/`)
- Test caches: `.coverage`, `.pytest_cache/`, `.hypothesis/`, `.ruff_cache/`, `.complexipy_cache/`
- OS: `.DS_Store`, `Thumbs.db`

## Notes

- Does NOT touch git history. Only prevents future tracking.
- `.gitmodules` excluded since no real submodules exist in the repo (the local one is leftover).

## Checklist
- [x] No code change
- [x] CHANGELOG updated (PR #104, just merged)

Generated with Claude <noreply@anthropic.com>