### PR TITLE
docs: document SVG + TSV outputs and add Example output section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ The cumulative event TSV
 ([`assets/qte77/gha-arbitrary-repo-timeline-activity.tsv`](assets/qte77/gha-arbitrary-repo-timeline-activity.tsv))
 preserves history beyond the rolling 30-day chart window:
 
+<!-- markdownlint-disable MD010 -->
 ```tsv
 2026-05-08	pr-merged	10
 2026-05-08	issue-opened	4
 2026-05-09	pr-opened	3
 ```
+<!-- markdownlint-enable MD010 -->
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Generate a timeline from issues, PRs, and git log across arbitrary repos.
 4. Optionally collects recent git log commits when `INCLUDE_GIT_LOG` is enabled
 5. Deduplicates entries against the existing timeline file to avoid repeats
 6. Appends new activity as a dated section to `timelines/<owner>/<repo>.md`
+7. Generates a themed activity SVG at `assets/<owner>/<repo>-activity.svg`
+   with auto light/dark mode (`prefers-color-scheme`)
+8. Maintains a cumulative event log at `assets/<owner>/<repo>-activity.tsv`
+   (deduped by date+event, last-write-wins)
 
 ## Inputs
 
@@ -37,6 +41,28 @@ Generate a timeline from issues, PRs, and git log across arbitrary repos.
 | `TOKEN` | No | `""` | GitHub token with read access to monitored repos |
 | `INCLUDE_GIT_LOG` | No | `false` | Include recent git log entries in timeline |
 | `DAYS` | No | `7` | Number of days to look back |
+
+## Example output
+
+This repo's own timeline is regenerated on every workflow run. See
+[`timelines/qte77/gha-arbitrary-repo-timeline.md`](timelines/qte77/gha-arbitrary-repo-timeline.md)
+for the live MD and the chart below for the live SVG (auto-themes
+in both GitHub light and dark modes):
+
+![Activity](https://raw.githubusercontent.com/qte77/gha-arbitrary-repo-timeline/main/assets/qte77/gha-arbitrary-repo-timeline-activity.svg)
+
+Color legend: PR opened/merged/closed (green/purple/red), issue
+opened/resolved/closed (blue/light-green/gray), commit (orange).
+
+The cumulative event TSV
+([`assets/qte77/gha-arbitrary-repo-timeline-activity.tsv`](assets/qte77/gha-arbitrary-repo-timeline-activity.tsv))
+preserves history beyond the rolling 30-day chart window:
+
+```tsv
+2026-05-08	pr-merged	10
+2026-05-08	issue-opened	4
+2026-05-09	pr-opened	3
+```
 
 ## License
 


### PR DESCRIPTION
## Summary

The README has been out of date since PR #84 (themed activity SVG) and PR #106 (cumulative TSV) — neither output was documented. Two surgical changes, no code touched.

## What changes

1. **`What it does` extended** with steps 7-8 covering the new SVG + TSV outputs.
2. **New `Example output` section** that embeds the live SVG via `raw.githubusercontent.com` and shows a 3-line TSV snippet. Uses the in-repo files as their own example — nothing pinned, nothing copied.

## Why concise

- No fixture pinning: the embedded `<img src="raw.githubusercontent.com/.../main/...">` tracks live `main`, so the README always shows the current state of this repo's own activity.
- Both linked files (the timeline MD and the TSV) are in-repo, so the relative links work both on github.com and any mirror.
- Color legend is documented inline so readers don't need to click through to the SVG to understand the categories.

## Test plan

- [x] markdownlint passes (PR check)
- [ ] Visual check on github.com once merged: SVG renders in both light and dark site themes; TSV link resolves; timeline MD link resolves

## Checklist

- [x] No code change
- [x] CHANGELOG (already current — `[Unreleased]` section in #104 covers PRs #84 and #106 that introduced these outputs)

Generated with Claude <noreply@anthropic.com>